### PR TITLE
remove address / switch email

### DIFF
--- a/src/pages/mentions-legales.astro
+++ b/src/pages/mentions-legales.astro
@@ -15,14 +15,9 @@ import Layout from "@/layouts/Layout.astro";
             Directrice de la publication<br />
             <strong>Aurore Stevens</strong><br />
           </p>
-          <address>
-            14 rue du Grand Pré<br />
-            35690 Acigné<br />
-            France
-          </address>
           <p class="legal__contact">
-            Contact: <a href="mailto:sylvain.hellegouarch@gmail.com"
-              >sylvain.hellegouarch@gmail.com</a
+            Contact: <a href="mailto:stevens-gardenbreche@gmail.com"
+              >stevens-gardenbreche@gmail.com</a
             >
           </p>
         </section>


### PR DESCRIPTION
I know the address is mandatory but I don't like having my home address exposed and the risks are nil. So let's not show it, when they turn famous they'll have an agent's address :D